### PR TITLE
Use description from extra if available

### DIFF
--- a/generate-database.py
+++ b/generate-database.py
@@ -2,6 +2,7 @@ import pandas as pd
 import sqlite3
 import os
 from datetime import datetime, timezone
+import json
 
 os.chdir("db_build")
 
@@ -105,6 +106,25 @@ df_sorted = df_sorted.sort_values(by=["category", "subcategory", "package"])
 
 # Remove parts with missing price fields
 df_sorted = df_sorted.drop(df_sorted[df_sorted["price"] == "[]"].index)
+
+# Description column is sometimes empty
+# Consider the description in extra as the authoritative source and use
+# column "description" only in case extra would not contain it.
+# This has been inspired by https://github.com/Bouni/kicad-jlcpcb-tools/pull/670
+def _extract_description(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        data = json.loads(value)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(data, dict):
+        return data.get("description")
+    return None
+
+if "extra" in df_sorted.columns:
+    extracted = df_sorted["extra"].apply(_extract_description)
+    df_sorted["description"] = extracted.where(extracted.notna(), df_sorted.get("description"))
 
 # Save sorted DataFrame to CSV
 df_sorted.to_csv("jlcpcb-components-basic-preferred.csv", index=False, header=True)

--- a/scrape-jlcpcb.py
+++ b/scrape-jlcpcb.py
@@ -149,7 +149,7 @@ total_unseen_components = 0
 while empty_page == False and page < 64:
     request_json = {
         "currentPage": page,
-        "pageSize": 100,
+        "pageSize": 25,
         "keyword": None,
         "componentLibraryType": "base",
         "preferredComponentFlag": True,


### PR DESCRIPTION
This partly addresses https://github.com/yaqwsx/jlcparts/issues/151 and https://github.com/CDFER/JLCPCB-Kicad-Library/issues/44.

It extracts description when it is available in "extra" column. There are still some components that do not have description and extra column, so this is not a complete fix. Previously there were 736 components without description (roughly a half), not it is 332 (roughly 1/5).

This also addresses https://github.com/CDFER/jlcpcb-parts-database/issues/8. It seems that JLCPBC API now refuses requests that ask for 100 entries. The web interface uses 25, which seems to work.